### PR TITLE
Fix the blurb

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,6 @@
 ## Paymenter
 
-Paymenter is an open source gateway for hosting companies. Paymenter is developed to provide an more easy way to manage your hosting company with many advanced features and addons. The project will include an official marketplace to sell or give away your modifications to the community.
+Paymenter is an open source gateway for hosting companies. It is developed to provide an easier way to manage your hosting company with many advanced features and addons. The project will include an official marketplace to sell or give away your modifications to the community.
 
 **Usefull information:**
 - https://github.com/Paymenter


### PR DESCRIPTION
This only fixes the blurb on the organization's GitHub page, but it also appears on the website (https://paymenter.org/) and probably elsewhere - these instances will probably have to be fixed separately.